### PR TITLE
Fixed cmake dependency logic and the timing hooks 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,12 +29,9 @@ endif()
 # Install GraphStreamingCC Project
 FetchContent_Declare(
   GraphStreamingCC
-  GIT_REPOSITORY      "https://github.com/GraphStreamingProject/GraphStreamingCC"
-  GIT_TAG             "main"
-  UPDATE_DISCONNECTED OFF
 
-  CMAKE_CACHE_ARGS
-    -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+  GIT_REPOSITORY      https://github.com/GraphStreamingProject/GraphStreamingCC
+  GIT_TAG             main
 )
 
 find_package(Boost 1.66.0)

--- a/query_expr/query_expr.cpp
+++ b/query_expr/query_expr.cpp
@@ -45,13 +45,11 @@ void perform_continuous_insertions(std::string binary_input, sys_config config) 
       auto end = std::chrono::steady_clock::now();
 
       std::cout << "Number CCs: " << res.size() << std::endl;
-      flush_times[i] = std::chrono::duration<double>(g.flush_return - g.flush_call).count();
-      backup_times[i] = std::chrono::duration<double>(g.create_backup_end - g.create_backup_start).count();
-      backup_times[i] += std::chrono::duration<double>(g.restore_backup_end - g.restore_backup_start).count();
+      flush_times[i] = std::chrono::duration<double>(g.flush_end - g.flush_start).count();
       cc_alg_times[i] = std::chrono::duration<double>(g.cc_alg_end - g.cc_alg_start).count();
       cc_tot_times[i] = std::chrono::duration<double>(end - cc_start).count();
       tot_times[i] = std::chrono::duration<double>(end - start).count();
-      insertion_times[i] = std::chrono::duration<double>(g.flush_return - start).count();
+      insertion_times[i] = std::chrono::duration<double>(g.flush_end - start).count();
 
       std::cout << i << ": " << cc_tot_times[i] << ", " << flush_times[i] << ", " << backup_times[i] << ", " << cc_alg_times[i] << ", " << tot_times[i] << ", " << insertion_times[i] << std::endl;
 

--- a/util/insertion_mgr.cpp
+++ b/util/insertion_mgr.cpp
@@ -119,7 +119,7 @@ void perform_insertions(std::string binary_input, std::string output_file, sys_c
   
   shutdown = true;
   querier.join();
-  std::chrono::duration<double> runtime = g.flush_return - start;
+  std::chrono::duration<double> runtime = g.flush_end - start;
   std::chrono::duration<double> CC_time = g.cc_alg_end - g.cc_alg_start;
 
   std::ofstream out{output_file,  std::ofstream::out | std::ofstream::app}; // open the outfile


### PR DESCRIPTION
Previously running `cmake ..` would not pull in updates from our other repos. This small change fixes this issue.

Additionally, the time hooks set in the GraphStreamingCC repo were changed so the query experiment needs to change to reflect that.